### PR TITLE
Refactor naming and add comments

### DIFF
--- a/src/test_gto.py
+++ b/src/test_gto.py
@@ -1,73 +1,68 @@
-from pathlib  import Path
+from pathlib import Path
 import unittest
 from gto import GTO
 
-class TestGTO(unittest.TestCase):
-    akq_game = Path(__file__).parent.parent / 'resources' / 'solves' / 'AKQ-Game.gto'
-    solver = GTO()
+"""
+Although using a unit testing library, these are integration tests. They require a running
+instance of GTO+.
+"""
 
-    def test_connect_and_disconnect(self):
-        s = self.solver
-        self.assertEqual(s.connect(), "You are connected to GTO+")
-        s.disconnect()
-        self.assertIsNone(s.sock)
+
+class TestGTO(unittest.TestCase):
+    def setUp(self):
+        self.akq_game = (
+            Path(__file__).parent.parent / "resources" / "solves" / "AKQ-Game.gto"
+        )
+        self.solver = GTO(verbose=True)
+        self.solver.connect()
+
+        result = self.solver.load_file(self.akq_game)
+
+        self.assertEqual(result, "File successfully loaded.")
+
+    def tearDown(self):
+        self.solver.disconnect()
 
     def test_load_file(self):
-        s = self.solver
-        s.connect()
-        self.assertEqual(s.load_file(self.akq_game), "File successfully loaded.")
-        s.disconnect()
+        result = self.solver.load_file(self.akq_game)
+        self.assertEqual(result, "File successfully loaded.")
 
     def test_request_node_data(self):
-        s = self.solver
-        s.connect()
-        s.load_file(self.akq_game)
-        node_data = s.request_node_data()
-        oop = node_data['oop']
-        ip = node_data['ip']
-        print(oop)
-        self.assertEqual(['Bet 1', 'Check'], node_data['actions'])
-        self.assertEqual('oop', node_data['pos'])
-        # TODO: test oop, ip
-        s.disconnect()
+        node_data = self.solver.request_node_data()
+
+        self.assertEqual("2d2c2h3d3c", node_data["board"])
+        self.assertEqual("oop", node_data["next_to_act"])
+        self.assertEqual(["Bet 1", "Check"], node_data["actions"])
 
     def test_request_pot_stacks(self):
-        s = self.solver
-        s.connect()
-        s.load_file(self.akq_game)
-        ps = s.request_pot_stacks()
-        self.assertEqual(1.0, ps['pot'])
-        self.assertEqual(1.0, ps['oop_stack'])
-        self.assertEqual(1.0, ps['ip_stack'])
-        s.disconnect()
+        pot_and_stacks = self.solver.request_pot_stacks()
+
+        self.assertEqual(1.0, pot_and_stacks["pot"])
+        self.assertEqual(1.0, pot_and_stacks["oop_stack"])
+        self.assertEqual(1.0, pot_and_stacks["ip_stack"])
 
     def test_request_current_line(self):
-        s = self.solver
-        s.connect()
-        s.load_file(self.akq_game)
-        self.assertEqual([], s.request_current_line())
-        s.disconnect()
+        current_line = self.solver.request_current_line()
+        self.assertEqual([], current_line)
 
-    def test_take_action(self):
-        s = self.solver
-        s.connect()
-        s.load_file(self.akq_game)
-        s.take_action(0)
-        nd = s.request_node_data()
-        self.assertEqual('ip', nd['pos'])
-        self.assertEqual(['Bet 1'], s.request_current_line())
-        
-        s.load_file(self.akq_game)
-        s.take_action(1)
-        nd = s.request_node_data()
-        self.assertEqual('ip', nd['pos'])
-        self.assertEqual(['Check'], s.request_current_line())
+    def test_take_first_action(self):
+        self.solver.take_action(0)
 
+        nd = self.solver.request_node_data()
+        self.assertEqual("ip", nd["next_to_act"])
 
+        current_line = self.solver.request_current_line()
+        self.assertEqual(["Bet 1"], current_line)
+
+    def test_take_second_action(self):
+        self.solver.take_action(1)
+
+        nd = self.solver.request_node_data()
+        self.assertEqual("ip", nd["next_to_act"])
+
+        current_line = self.solver.request_current_line()
+        self.assertEqual(["Check"], current_line)
 
 
-
-
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This commit only tangentially alters functionality. It mainly changes
the names of methods and variables while adding substantial comments.
It uses Black as formatter.

The comments focus the response format of GTO+. These responses are
dense and require non-trivial parsing. The comments should make it
easier to understand _why_ the code is written the way it is and, more
importantly, make it easier to update if GTO+ changes its format.

Other changes include moving or defining magic numbers and refactoring
methods according to their level of abstraction. For example, in
`request_node_data` there are now multiple `get` methods. These perform
the calls to GTO+ and parsing of the reponse. Because this code is at a
lower level of abstraction, it gets its own method. The intent is to
allow the reader to dive deeper only when they feel the need while
relying on naming to indicate _what_ something does rather than _how_.
If the reader is interested in the how, they can drop down a level of
abstraction to the helper method.

Lastly, this commit rearranges methods and uses underscores to indicate
intended visibility. That is, methods with an underscore are intended to
be private; they are helper methods. Publicly available methods
generally precede these helper methods.

In follow-up commits, I plan to add comments to methods currently marked
with TODOs, add type-hinting, and add logging levels to make future
development easier.